### PR TITLE
Make verifier methods immutable borrows with mutex wrapped cache

### DIFF
--- a/trustchain-core/src/verifier.rs
+++ b/trustchain-core/src/verifier.rs
@@ -249,7 +249,7 @@ impl VerifiableTimestamp {
 pub trait Verifier<T: Sync + Send + DIDResolver> {
     /// Verifies a downstream DID by tracing its chain back to the root.
     async fn verify(
-        &mut self,
+        &self,
         did: &str,
         root_timestamp: Timestamp,
     ) -> Result<DIDChain, VerifierError> {
@@ -277,10 +277,7 @@ pub trait Verifier<T: Sync + Send + DIDResolver> {
 
     /// Constructs a verifiable timestamp for the given DID, including an expected
     /// value for the timestamp retreived from a local PoW network node.
-    async fn verifiable_timestamp(
-        &mut self,
-        did: &str,
-    ) -> Result<VerifiableTimestamp, VerifierError> {
+    async fn verifiable_timestamp(&self, did: &str) -> Result<VerifiableTimestamp, VerifierError> {
         // Get the DID Commitment.
         let did_commitment = self.did_commitment(did).await?;
         // Hash the DID commitment
@@ -326,7 +323,7 @@ pub trait Verifier<T: Sync + Send + DIDResolver> {
     /// Gets a block hash (PoW) Commitment for the given DID.
     /// The mutable reference to self enables a newly-fetched Commitment
     /// to be stored locally for faster subsequent retrieval.
-    async fn did_commitment(&mut self, did: &str) -> Result<Box<dyn DIDCommitment>, VerifierError>;
+    async fn did_commitment(&self, did: &str) -> Result<Box<dyn DIDCommitment>, VerifierError>;
 
     /// Gets the resolver used for DID verification.
     fn resolver(&self) -> &Resolver<T>;

--- a/trustchain-ion/src/bin/main.rs
+++ b/trustchain-ion/src/bin/main.rs
@@ -173,7 +173,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     }
 
                     // Trustchain verify the issued credential
-                    let mut verifier = IONVerifier::new(get_ion_resolver("http://localhost:3000/"));
+                    let verifier = IONVerifier::new(get_ion_resolver("http://localhost:3000/"));
 
                     let issuer = match credential.issuer {
                         Some(ssi::vc::Issuer::URI(URI::String(did))) => did,

--- a/trustchain-ion/tests/verifier.rs
+++ b/trustchain-ion/tests/verifier.rs
@@ -20,7 +20,7 @@ async fn trustchain_verification() {
 
     // Construct a Trustchain Resolver from a Sidetree (ION) DIDMethod.
     let resolver = get_ion_resolver("http://localhost:3000/");
-    let mut verifier = IONVerifier::new(resolver);
+    let verifier = IONVerifier::new(resolver);
     for did in dids {
         let result = verifier.verify(did, ROOT_EVENT_TIME_1).await;
         assert!(result.is_ok());
@@ -31,7 +31,7 @@ async fn trustchain_verification() {
 #[ignore = "Integration test requires ION, Bitcoin RPC & IPFS"]
 async fn test_verifiable_timestamp() {
     let resolver = get_ion_resolver("http://localhost:3000/");
-    let mut target = IONVerifier::new(resolver);
+    let target = IONVerifier::new(resolver);
 
     let did = "did:ion:test:EiCClfEdkTv_aM3UnBBhlOV89LlGhpQAbfeZLFdFxVFkEg";
     let result = target.verifiable_timestamp(did).await;


### PR DESCRIPTION
Closes #87.

- Removes mutable borrows for `Verifier` trait and `IONVerifier` methods with `Mutex` wrapping the bundles field, with `VerificationBundle` values stored in an `Arc`.
- Removes no longer required `fetch_did_commitment()` and `bundles()` methods
