### PR TITLE
104 filter timestamp commitment

### DIFF
--- a/trustchain-core/Cargo.toml
+++ b/trustchain-core/Cargo.toml
@@ -19,7 +19,7 @@ petgraph = {version = "0.6"}
 serde = { version = "1.0", features = ["derive"] }
 serde_jcs = "0.1.0"
 serde_json = "1.0"
-sha2 = "0.10"
+sha2 = "0.10.7"
 ssi = { version = "0.4", features = ["http-did", "secp256k1"] }
 tempfile = { version = "3.3" }
 thiserror = "1.0"

--- a/trustchain-core/src/commitment.rs
+++ b/trustchain-core/src/commitment.rs
@@ -272,11 +272,19 @@ pub trait DIDCommitment: Commitment {
 /// A Commitment whose expected data is a Unix time.
 pub trait TimestampCommitment: Commitment {
     /// Gets the timestamp as a Unix time.
-    fn timestamp(&self) -> Timestamp {
+    fn timestamp(&self) -> CommitmentResult<Timestamp> {
         self.expected_data()
             .as_u64()
-            .unwrap()
+            .ok_or(CommitmentError::DataDecodingError(format!(
+                "Could not convert the following expected data to u64: {}",
+                self.expected_data()
+            )))?
             .try_into()
-            .expect("Construction guarantees u32.")
+            .map_err(|err| {
+                CommitmentError::DataDecodingError(format!(
+                    "Could not convert u64 into Timestamp (u32): {}",
+                    err
+                ))
+            })
     }
 }

--- a/trustchain-core/src/verifier.rs
+++ b/trustchain-core/src/verifier.rs
@@ -2,9 +2,7 @@
 use std::error::Error;
 
 use crate::chain::{Chain, ChainError, DIDChain};
-use crate::commitment::{
-    Commitment, CommitmentError, DIDCommitment, TimestampCommitment, TrivialCommitment,
-};
+use crate::commitment::{CommitmentError, DIDCommitment, TimestampCommitment};
 use crate::resolver::{Resolver, ResolverError};
 use async_trait::async_trait;
 use ssi::did_resolve::DIDResolver;

--- a/trustchain-core/src/verifier.rs
+++ b/trustchain-core/src/verifier.rs
@@ -174,7 +174,7 @@ pub trait VerifiableTimestamp {
     /// Gets the wrapped TimestampCommitment.
     fn timestamp_commitment(&self) -> &dyn TimestampCommitment;
     /// Gets the Timestamp.
-    fn timestamp(&self) -> Timestamp;
+    fn timestamp(&self) -> Result<Timestamp, CommitmentError>;
     /// Verifies both the DIDCommitment and the TimestampCommitment against the same target.
     fn verify(&self, target: &str) -> Result<(), CommitmentError> {
         // The expected data in the TimestampCommitment is the timestamp, while in the
@@ -215,7 +215,7 @@ pub trait Verifier<T: Sync + Send + DIDResolver> {
         // At this point we know that the same, valid PoW commits to both the timestamp
         // in verifiable_timestamp and the data (keys & endpoints) in the root DID Document.
         // It only remains to check that the verified timestamp matches the expected root timestamp.
-        if !verifiable_timestamp.timestamp().eq(&root_timestamp) {
+        if !verifiable_timestamp.timestamp()?.eq(&root_timestamp) {
             Err(VerifierError::InvalidRoot(root.to_string()))
         } else {
             Ok(chain)

--- a/trustchain-core/src/verifier.rs
+++ b/trustchain-core/src/verifier.rs
@@ -174,7 +174,7 @@ pub trait VerifiableTimestamp {
     /// Gets the wrapped TimestampCommitment.
     fn timestamp_commitment(&self) -> &dyn TimestampCommitment;
     /// Gets the Timestamp.
-    fn timestamp(&self) -> Result<Timestamp, CommitmentError>;
+    fn timestamp(&self) -> Timestamp;
     /// Verifies both the DIDCommitment and the TimestampCommitment against the same target.
     fn verify(&self, target: &str) -> Result<(), CommitmentError> {
         // The expected data in the TimestampCommitment is the timestamp, while in the
@@ -215,7 +215,7 @@ pub trait Verifier<T: Sync + Send + DIDResolver> {
         // At this point we know that the same, valid PoW commits to both the timestamp
         // in verifiable_timestamp and the data (keys & endpoints) in the root DID Document.
         // It only remains to check that the verified timestamp matches the expected root timestamp.
-        if !verifiable_timestamp.timestamp()?.eq(&root_timestamp) {
+        if !verifiable_timestamp.timestamp().eq(&root_timestamp) {
             Err(VerifierError::InvalidRoot(root.to_string()))
         } else {
             Ok(chain)

--- a/trustchain-core/src/verifier.rs
+++ b/trustchain-core/src/verifier.rs
@@ -174,7 +174,7 @@ pub trait VerifiableTimestamp {
     /// Gets the wrapped DIDCommitment.
     fn did_commitment(&self) -> &dyn DIDCommitment;
     /// Gets the wrapped TimestampCommitment.
-    fn timestamp_commitment(&self) -> &TimestampCommitment;
+    fn timestamp_commitment(&self) -> &dyn TimestampCommitment;
     /// Gets the Timestamp.
     fn timestamp(&self) -> Timestamp;
     /// Verifies both the DIDCommitment and the TimestampCommitment against the same target.

--- a/trustchain-ion/Cargo.toml
+++ b/trustchain-ion/Cargo.toml
@@ -30,7 +30,7 @@ reqwest = "0.11"
 serde = { version = "1.0", features = ["derive"] }
 serde_jcs = "0.1.0"
 serde_json = "1.0"
-sha256 = "1.1.1"
+sha2 = "0.10.7"
 ssi = { version = "0.4", features = ["http-did", "secp256k1"] }
 thiserror = "1.0"
 toml="0.7.2"

--- a/trustchain-ion/src/commitment.rs
+++ b/trustchain-ion/src/commitment.rs
@@ -624,12 +624,10 @@ impl TimestampCommitment for BlockTimestampCommitment {}
 
 #[cfg(test)]
 mod tests {
-
-    use std::str::FromStr;
-
+    use bitcoin::util::psbt::serialize::Serialize;
     use bitcoin::BlockHash;
-    use bitcoin::{util::psbt::serialize::Serialize, BlockHeader};
     use ipfs_api_backend_hyper::IpfsClient;
+    use std::str::FromStr;
     use trustchain_core::{data::TEST_ROOT_DOCUMENT, utils::json_contains};
 
     use super::*;

--- a/trustchain-ion/src/commitment.rs
+++ b/trustchain-ion/src/commitment.rs
@@ -566,7 +566,7 @@ impl DIDCommitment for IONCommitment {
 /// A Commitment whose expected data is a Unix time and hasher
 /// and candidate data are obtained from a given DIDCommitment.
 pub struct BlockTimestampCommitment {
-    expected_data: serde_json::Value,
+    expected_data: Timestamp,
     candidate_data: Vec<u8>,
 }
 
@@ -575,13 +575,13 @@ impl BlockTimestampCommitment {
         // The decoded candidate data must contain the timestamp such that it is found
         // by the json_contains function, otherwise the content verification will fail.
         Ok(Self {
-            expected_data: json!(expected_data),
+            expected_data,
             candidate_data,
         })
     }
 }
 
-impl TrivialCommitment for BlockTimestampCommitment {
+impl TrivialCommitment<Timestamp> for BlockTimestampCommitment {
     fn hasher(&self) -> fn(&[u8]) -> CommitmentResult<String> {
         block_header_hasher()
     }
@@ -609,13 +609,13 @@ impl TrivialCommitment for BlockTimestampCommitment {
         }))
     }
 
-    fn to_commitment(self: Box<Self>, _: serde_json::Value) -> Box<dyn Commitment> {
+    fn to_commitment(self: Box<Self>, _: Timestamp) -> Box<dyn Commitment<Timestamp>> {
         self
     }
 }
 
-impl Commitment for BlockTimestampCommitment {
-    fn expected_data(&self) -> &serde_json::Value {
+impl Commitment<Timestamp> for BlockTimestampCommitment {
+    fn expected_data(&self) -> &Timestamp {
         &self.expected_data
     }
 }

--- a/trustchain-ion/src/commitment.rs
+++ b/trustchain-ion/src/commitment.rs
@@ -571,7 +571,7 @@ pub struct BlockTimestampCommitment {
 }
 
 impl BlockTimestampCommitment {
-    pub fn new(expected_data: Timestamp, candidate_data: Vec<u8>) -> CommitmentResult<Self> {
+    pub fn new(candidate_data: Vec<u8>, expected_data: Timestamp) -> CommitmentResult<Self> {
         // The decoded candidate data must contain the timestamp such that it is found
         // by the json_contains function, otherwise the content verification will fail.
         Ok(Self {
@@ -640,14 +640,14 @@ mod tests {
     fn test_block_timestamp_commitment() {
         let expected_data: Timestamp = 1666265405;
         let candidate_data = hex::decode(TEST_BLOCK_HEADER_HEX).unwrap();
-        let target = BlockTimestampCommitment::new(expected_data, candidate_data.clone()).unwrap();
+        let target = BlockTimestampCommitment::new(candidate_data.clone(), expected_data).unwrap();
         target.verify_content().unwrap();
         let pow_hash = "000000000000000eaa9e43748768cd8bf34f43aaa03abd9036c463010a0c6e7f";
         target.verify(pow_hash).unwrap();
 
         // Both calls should instead error with incorrect timestamp
         let bad_expected_data: Timestamp = 1666265406;
-        let target = BlockTimestampCommitment::new(bad_expected_data, candidate_data).unwrap();
+        let target = BlockTimestampCommitment::new(candidate_data, bad_expected_data).unwrap();
         match target.verify_content() {
             Err(CommitmentError::FailedContentVerification(s1, s2)) => {
                 assert_eq!(
@@ -862,11 +862,11 @@ mod tests {
         // Also test as timestamp commitment
         let expected_data = 1666265405;
         let commitment =
-            BlockTimestampCommitment::new(expected_data, candidate_data.clone()).unwrap();
+            BlockTimestampCommitment::new(candidate_data.clone(), expected_data).unwrap();
         commitment.verify_content().unwrap();
         commitment.verify(target).unwrap();
         let bad_expected_data = 1666265406;
-        let commitment = BlockTimestampCommitment::new(bad_expected_data, candidate_data).unwrap();
+        let commitment = BlockTimestampCommitment::new(candidate_data, bad_expected_data).unwrap();
         assert!(commitment.verify_content().is_err());
         assert!(commitment.verify(target).is_err());
     }

--- a/trustchain-ion/src/verifier.rs
+++ b/trustchain-ion/src/verifier.rs
@@ -614,7 +614,7 @@ impl VerifiableTimestamp for IONTimestamp {
         self.timestamp_commitment.as_ref()
     }
 
-    fn timestamp(&self) -> Timestamp {
+    fn timestamp(&self) -> Result<Timestamp, CommitmentError> {
         self.timestamp_commitment().timestamp()
     }
 }

--- a/trustchain-ion/src/verifier.rs
+++ b/trustchain-ion/src/verifier.rs
@@ -24,7 +24,7 @@ use std::marker::PhantomData;
 use std::str::FromStr;
 use std::sync::{Arc, Mutex};
 use trustchain_core::commitment::{
-    CommitmentChain, CommitmentError, DIDCommitment, TimestampCommitment, TrivialCommitment,
+    CommitmentChain, CommitmentError, DIDCommitment, TimestampCommitment,
 };
 use trustchain_core::resolver::{Resolver, ResolverError};
 use trustchain_core::utils::get_did_suffix;

--- a/trustchain-ion/src/verifier.rs
+++ b/trustchain-ion/src/verifier.rs
@@ -614,7 +614,7 @@ impl VerifiableTimestamp for IONTimestamp {
         self.timestamp_commitment.as_ref()
     }
 
-    fn timestamp(&self) -> Result<Timestamp, CommitmentError> {
+    fn timestamp(&self) -> Timestamp {
         self.timestamp_commitment().timestamp()
     }
 }

--- a/trustchain-ion/src/verifier.rs
+++ b/trustchain-ion/src/verifier.rs
@@ -501,7 +501,6 @@ where
             .downcast_ref::<IONCommitment>()
             .unwrap(); // Safe because IONCommitment implements DIDCommitment.
         let timestamp_commitment = Box::new(BlockTimestampCommitment::new(
-            expected_timestamp,
             ion_commitment
                 .chained_commitment()
                 .commitments()
@@ -509,6 +508,7 @@ where
                 .expect("Unexpected empty commitment chain.")
                 .candidate_data()
                 .to_owned(),
+            expected_timestamp,
         )?);
         Ok(Box::new(IONTimestamp::new(
             did_commitment,
@@ -562,7 +562,6 @@ where
             .downcast_ref::<IONCommitment>()
             .unwrap(); // Safe because IONCommitment implements DIDCommitment.
         let timestamp_commitment = Box::new(BlockTimestampCommitment::new(
-            expected_timestamp,
             ion_commitment
                 .chained_commitment()
                 .commitments()
@@ -570,6 +569,7 @@ where
                 .expect("Unexpected empty commitment chain.")
                 .candidate_data()
                 .to_owned(),
+            expected_timestamp,
         )?);
         Ok(Box::new(IONTimestamp::new(
             did_commitment,

--- a/trustchain-ion/tests/verifier.rs
+++ b/trustchain-ion/tests/verifier.rs
@@ -53,7 +53,7 @@ async fn test_verifiable_timestamp() {
     );
 
     // Check that the DID timestamp is correct by comparing to the known header.
-    assert_eq!(verifiable_timestamp.timestamp().unwrap(), timestamp);
+    assert_eq!(verifiable_timestamp.timestamp(), timestamp);
 
     // Confirm that the same timestamp is the expected data in the TimestampCommitment.
     assert_eq!(

--- a/trustchain-ion/tests/verifier.rs
+++ b/trustchain-ion/tests/verifier.rs
@@ -54,7 +54,7 @@ async fn test_verifiable_timestamp() {
     );
 
     // Check that the DID timestamp is correct by comparing to the known header.
-    assert_eq!(verifiable_timestamp.timestamp(), timestamp);
+    assert_eq!(verifiable_timestamp.timestamp().unwrap(), timestamp);
 
     // Confirm that the same timestamp is the expected data in the TimestampCommitment.
     assert_eq!(

--- a/trustchain-ion/tests/verifier.rs
+++ b/trustchain-ion/tests/verifier.rs
@@ -1,5 +1,4 @@
 use serde_json::json;
-use trustchain_core::commitment::{Commitment, TrivialCommitment};
 use trustchain_core::verifier::{Timestamp, Verifier};
 use trustchain_ion::get_ion_resolver;
 use trustchain_ion::verifier::IONVerifier;


### PR DESCRIPTION
Addresses #104.

It includes the filtering and I've added a couple of tests to make sure it works ok.

Also the `verifiable_timestamp()` method in `IONVerifier` is a bit simpler because the hasher and decoder are now free functions and baked in to the `BlockTimestampCommitment`.

But the new `TimestampCommitment` trait [isn't ideal](https://github.com/alan-turing-institute/trustchain/issues/104#issuecomment-1645962625). Can we improve that?