### PR TITLE
Add default implementation for timestamp() method

### DIFF
--- a/trustchain-core/src/verifier.rs
+++ b/trustchain-core/src/verifier.rs
@@ -18,8 +18,11 @@ pub enum VerifierError {
     #[error("Invalid signature for proof in dDID: {0}.")]
     InvalidSignature(String),
     /// Invalid root DID after self-controller reached in path.
-    #[error("Invalid root DID: {0}.")]
-    InvalidRoot(String),
+    #[error("Invalid root DID error: {0}")]
+    InvalidRoot(Box<dyn std::error::Error>),
+    /// Invalid root with error:
+    #[error("Invalid root DID ({0}) with timestamp: {1}.")]
+    InvalidRootTimestamp(String, Timestamp),
     /// Failed to build DID chain.
     #[error("Failed to build chain: {0}.")]
     ChainBuildFailure(String),
@@ -220,7 +223,10 @@ pub trait Verifier<T: Sync + Send + DIDResolver> {
         // Verify explicitly that the return value from the timestamp method equals the expected
         // root timestamp (in case the default timestamp method implementation has been overridden).
         if !verifiable_timestamp.timestamp().eq(&root_timestamp) {
-            Err(VerifierError::InvalidRoot(root.to_string()))
+            Err(VerifierError::InvalidRootTimestamp(
+                root.to_string(),
+                verifiable_timestamp.timestamp(),
+            ))
         } else {
             Ok(chain)
         }

--- a/trustchain-core/src/verifier.rs
+++ b/trustchain-core/src/verifier.rs
@@ -210,14 +210,15 @@ pub trait Verifier<T: Sync + Send + DIDResolver> {
 
         let verifiable_timestamp = self.verifiable_timestamp(root, root_timestamp).await?;
 
-        // Verify that the root DID content (keys & endpoints) and the timestamp share a common commitment target.
+        // Verify that the root DID content (keys & endpoints) and the timestamp share a common
+        // commitment target.
         verifiable_timestamp.verify(&verifiable_timestamp.timestamp_commitment().hash()?)?;
 
         // Validate the PoW on the common target hash.
         self.validate_pow_hash(&verifiable_timestamp.timestamp_commitment().hash()?)?;
 
-        // Verify explicitly that the return value from the timestamp method equals the expected root timestamp
-        // (in case the default timestamp method implementation has been overridden).
+        // Verify explicitly that the return value from the timestamp method equals the expected
+        // root timestamp (in case the default timestamp method implementation has been overridden).
         if !verifiable_timestamp.timestamp().eq(&root_timestamp) {
             Err(VerifierError::InvalidRoot(root.to_string()))
         } else {

--- a/trustchain-http/src/resolver.rs
+++ b/trustchain-http/src/resolver.rs
@@ -72,9 +72,7 @@ impl TrustchainHTTP for TrustchainHTTPHandler {
             .await
             // Any commitment error implies invalid root
             .map_err(|err| match err {
-                err @ VerifierError::CommitmentFailure(_) => {
-                    VerifierError::InvalidRoot(format!("{err}"))
-                }
+                err @ VerifierError::CommitmentFailure(_) => VerifierError::InvalidRoot(err.into()),
                 err => err,
             })?;
         debug!("Verified did...");
@@ -243,7 +241,7 @@ mod tests {
         assert!(response
             .text()
             .await
-            .starts_with(r#"{"error":"Trustchain Verifier error: Invalid root DID:"#),)
+            .starts_with(r#"{"error":"Trustchain Verifier error: Invalid root DID error:"#),)
     }
 
     #[tokio::test]

--- a/trustchain-ion/src/verifier.rs
+++ b/trustchain-ion/src/verifier.rs
@@ -612,10 +612,6 @@ impl VerifiableTimestamp for IONTimestamp {
     fn timestamp_commitment(&self) -> &dyn TimestampCommitment {
         self.timestamp_commitment.as_ref()
     }
-
-    fn timestamp(&self) -> Timestamp {
-        self.timestamp_commitment().timestamp()
-    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This aims to fix the redundancy observed in the core `Verifier` default implementation of the `verify()` method.