### PR TITLE
Remove ion_endpoint in trustchain-ffi

### DIFF
--- a/trustchain-ffi/src/config.rs
+++ b/trustchain-ffi/src/config.rs
@@ -37,26 +37,22 @@ struct Config {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct EndpointOptions {
-    pub ion_endpoint: Endpoint,
-    pub trustchain_endpoint: Option<Endpoint>,
+    pub trustchain_endpoint: Endpoint,
 }
 
 impl EndpointOptions {
-    pub fn ion_endpoint(&self) -> &Endpoint {
-        &self.ion_endpoint
-    }
-    pub fn trustchain_endpoint(&self) -> anyhow::Result<&Endpoint> {
-        self.trustchain_endpoint
-            .as_ref()
-            .ok_or_else(|| anyhow!("Expected trustchain endpoint."))
+    pub fn trustchain_endpoint(&self) -> &Endpoint {
+        &self.trustchain_endpoint
+        // self.trustchain_endpoint
+        //     .as_ref()
+        //     .ok_or_else(|| anyhow!("Expected trustchain endpoint."))
     }
 }
 
 impl Default for EndpointOptions {
     fn default() -> Self {
         Self {
-            ion_endpoint: Endpoint::new(URL::from("http://127.0.0.1"), 3000),
-            trustchain_endpoint: Some(Endpoint::new(URL::from("http://127.0.0.1"), 8081)),
+            trustchain_endpoint: Endpoint::new(URL::from("http://127.0.0.1"), 8081),
         }
     }
 }
@@ -116,10 +112,6 @@ mod tests {
 
     const TEST_ENDPOINT_OPTIONS: &str = r#"
         {
-            "ionEndpoint": {
-                "host": "http://127.0.0.1",
-                "port": 3000
-            },
             "trustchainEndpoint": {
                 "host": "http://127.0.0.1",
                 "port": 8081
@@ -142,9 +134,6 @@ mod tests {
     "#;
 
     const TEST_FFI_OPTIONS: &str = r#"
-    [ffi.endpointOptions.ionEndpoint]
-    host="http://127.0.0.1"
-    port=3000
     [ffi.endpointOptions.trustchainEndpoint]
     host="http://127.0.0.1"
     port=8081
@@ -192,7 +181,6 @@ mod tests {
                 .endpoint()
                 .unwrap()
                 .trustchain_endpoint()
-                .unwrap()
                 .port,
             8081
         );

--- a/trustchain-ffi/src/config.rs
+++ b/trustchain-ffi/src/config.rs
@@ -43,9 +43,6 @@ pub struct EndpointOptions {
 impl EndpointOptions {
     pub fn trustchain_endpoint(&self) -> &Endpoint {
         &self.trustchain_endpoint
-        // self.trustchain_endpoint
-        //     .as_ref()
-        //     .ok_or_else(|| anyhow!("Expected trustchain endpoint."))
     }
 }
 

--- a/trustchain-ffi/src/mobile.rs
+++ b/trustchain-ffi/src/mobile.rs
@@ -52,7 +52,7 @@ pub fn greet() -> String {
 pub fn did_resolve(did: String, opts: String) -> Result<String> {
     let mobile_opts: FFIConfig = opts.parse()?;
     let endpoint_opts = mobile_opts.endpoint()?;
-    let resolver = get_ion_resolver(&endpoint_opts.ion_endpoint().to_address());
+    let resolver = get_ion_resolver(&endpoint_opts.trustchain_endpoint().to_address());
     let rt = Runtime::new().unwrap();
     rt.block_on(async {
         Ok(TrustchainAPI::resolve(&did, &resolver)
@@ -73,8 +73,8 @@ pub fn did_verify(did: String, opts: String) -> Result<String> {
     let rt = Runtime::new().unwrap();
     rt.block_on(async {
         let verifier = IONVerifier::with_endpoint(
-            get_ion_resolver(&endpoint_opts.ion_endpoint().to_address()),
-            endpoint_opts.trustchain_endpoint()?.to_address(),
+            get_ion_resolver(&endpoint_opts.trustchain_endpoint().to_address()),
+            endpoint_opts.trustchain_endpoint().to_address(),
         );
         Ok(TrustchainAPI::verify(&did, root_event_time, &verifier)
             .await
@@ -95,8 +95,8 @@ pub fn vc_verify_credential(credential: String, opts: String) -> Result<String> 
     let rt = Runtime::new().unwrap();
     rt.block_on(async {
         let verifier = IONVerifier::with_endpoint(
-            get_ion_resolver(&endpoint_opts.ion_endpoint().to_address()),
-            endpoint_opts.trustchain_endpoint()?.to_address(),
+            get_ion_resolver(&endpoint_opts.trustchain_endpoint().to_address()),
+            endpoint_opts.trustchain_endpoint().to_address(),
         );
         let root_event_time = trustchain_opts.root_event_time;
 
@@ -154,7 +154,7 @@ pub fn vp_issue_presentation(
     let mut presentation: Presentation =
         serde_json::from_str(&presentation).map_err(FFIMobileError::FailedToDeserialize)?;
     let jwk: JWK = serde_json::from_str(&jwk_json)?;
-    let resolver = get_ion_resolver(&endpoint_opts.ion_endpoint().to_address());
+    let resolver = get_ion_resolver(&endpoint_opts.trustchain_endpoint().to_address());
     let rt = Runtime::new().unwrap();
     let proof = rt
         .block_on(async {
@@ -186,8 +186,6 @@ mod tests {
     signatureOnly = false
 
     [ffi.endpointOptions]
-    ionEndpoint.host = "127.0.0.1"
-    ionEndpoint.port = 3000
     trustchainEndpoint.host = "127.0.0.1"
     trustchainEndpoint.port = 8081
     "#;


### PR DESCRIPTION
Closes #136.

Removes `ion_endpoint` in the `EndpointOptions` inside `FFIConfig`. Makes the `trustchain_endpoint` non-optional.

This change is needed to support the removal of the `ionEndpoint` config setting in trustchain-mobile (see [issue #60](https://github.com/alan-turing-institute/trustchain-mobile/issues/60)).