### PR TITLE
Add data credential signing & verification to the CLI

### DIFF
--- a/trustchain-api/Cargo.toml
+++ b/trustchain-api/Cargo.toml
@@ -12,6 +12,7 @@ ps_sig = { git = "https://github.com/alan-turing-institute/RSS.git", rev = "ec93
 
 async-trait = "0.1"
 serde_json = "1.0"
+sha2 = "0.10.7"
 ssi = { git = "https://github.com/alan-turing-institute/ssi.git", rev = "1aa3223a384ee71df1333bbce04af445e852eab5", features = [
     "http-did",
     "secp256k1",
@@ -19,6 +20,8 @@ ssi = { git = "https://github.com/alan-turing-institute/ssi.git", rev = "1aa3223
 ] }
 did-ion = { git = "https://github.com/alan-turing-institute/ssi.git", rev = "1aa3223a384ee71df1333bbce04af445e852eab5" }
 futures = "0.3.28"
+hex = "0.4.3"
+xattr = "1.3.1"
 
 [dev-dependencies]
 tokio = { version = "1.20.1", features = ["full"] }

--- a/trustchain-api/Cargo.toml
+++ b/trustchain-api/Cargo.toml
@@ -11,6 +11,7 @@ trustchain-ion = { path = "../trustchain-ion" }
 ps_sig = { git = "https://github.com/alan-turing-institute/RSS.git", rev = "ec9386e125d87c5f54898b34fbe0883b3b36ffd4" }
 
 async-trait = "0.1"
+chrono = "0.4"
 serde_json = "1.0"
 sha2 = "0.10.7"
 ssi = { git = "https://github.com/alan-turing-institute/ssi.git", rev = "1aa3223a384ee71df1333bbce04af445e852eab5", features = [
@@ -21,7 +22,6 @@ ssi = { git = "https://github.com/alan-turing-institute/ssi.git", rev = "1aa3223
 did-ion = { git = "https://github.com/alan-turing-institute/ssi.git", rev = "1aa3223a384ee71df1333bbce04af445e852eab5" }
 futures = "0.3.28"
 hex = "0.4.3"
-xattr = "1.3.1"
 
 [dev-dependencies]
 tokio = { version = "1.20.1", features = ["full"] }

--- a/trustchain-api/src/api.rs
+++ b/trustchain-api/src/api.rs
@@ -328,14 +328,14 @@ pub trait TrustchainDataAPI {
         };
         // Verify the data credential.
         TrustchainAPI::verify_credential(
-            &credential,
+            credential,
             linked_data_proof_options,
             root_event_time,
             verifier,
             context_loader,
         )
         .await
-        .map_err(|e| DataCredentialError::CredentialError(e))
+        .map_err(DataCredentialError::CredentialError)
     }
 }
 
@@ -429,7 +429,7 @@ mod tests {
         assert!(res.is_ok());
 
         // Change credential to make signature invalid
-        vc_with_proof.expiration_date = Some(VCDateTime::try_from(now_ns()).unwrap());
+        vc_with_proof.expiration_date = Some(VCDateTime::from(now_ns()));
 
         // Verify: expect no warnings and a signature error as VC has changed
         let resolver = trustchain_resolver("http://localhost:3000/");
@@ -718,15 +718,15 @@ mod tests {
         let issuer_did = "did:ion:test:EiBVpjUxXeSRJpvj2TewlX9zNF3GKMCKWwGmKBZqF6pk_A"; // root+1
 
         let bytes = "test-data-content".as_bytes();
-        let expected_hash = hex::encode(Sha256::digest(&bytes));
+        let expected_hash = hex::encode(Sha256::digest(bytes));
 
-        let vc_with_proof = signed_data_credential(issuer_did, &bytes).await;
+        let vc_with_proof = signed_data_credential(issuer_did, bytes).await;
 
         let resolver = trustchain_resolver("http://localhost:3000/");
         let mut context_loader = ContextLoader::default();
 
         let res = TrustchainAPI::verify_data(
-            &bytes,
+            bytes,
             &vc_with_proof,
             None,
             ROOT_EVENT_TIME_1,
@@ -742,7 +742,7 @@ mod tests {
         // Verify: expect no warnings and a MismatchedHashDigests error as the data has changed.
         let resolver = trustchain_resolver("http://localhost:3000/");
         let res = TrustchainAPI::verify_data(
-            &bytes,
+            bytes,
             &vc_with_proof,
             None,
             ROOT_EVENT_TIME_1,

--- a/trustchain-api/src/api.rs
+++ b/trustchain-api/src/api.rs
@@ -311,12 +311,18 @@ pub trait TrustchainDataAPI {
         let expected_hash = credential
             .credential_subject
             .to_single()
-            .unwrap() // TODO: handle error with ?
+            .ok_or(DataCredentialError::ManyCredentialSubject(
+                credential.credential_subject.clone(),
+            ))?
             .property_set
             .as_ref()
-            .unwrap() // TODO: handle error with ?
+            .ok_or(DataCredentialError::MissingAttribute(
+                "property_set".to_string(),
+            ))?
             .get(DATA_ATTRIBUTE)
-            .unwrap() // TODO: handle error with ?
+            .ok_or(DataCredentialError::MissingAttribute(
+                DATA_ATTRIBUTE.to_string(),
+            ))?
             .as_str()
             .expect("dataset attribute is a str");
 

--- a/trustchain-api/src/lib.rs
+++ b/trustchain-api/src/lib.rs
@@ -10,7 +10,12 @@ impl TrustchainVCAPI for TrustchainAPI {}
 impl TrustchainVPAPI for TrustchainAPI {}
 impl TrustchainDataAPI for TrustchainAPI {}
 
-pub(crate) const DATASET_CREDENTIAL_TEMPLATE: &str = r###"
+/// A template for data credentials.
+/// Uses the dataset attribute from schema.org.
+/// The context (i.e. "https://schema.org/") is checked by the SSI library against the list at:
+/// https://github.com/spruceid/ssi/blob/976e2607080c20cd5789b977e477e98b6417f8af/ssi-json-ld/src/lib.rs#L41
+/// with an exact string match. (Therefore the trailing "/" is required.)
+pub(crate) const DATA_CREDENTIAL_TEMPLATE: &str = r###"
 {
     "@context": [
       "https://www.w3.org/2018/credentials/v1",
@@ -27,4 +32,4 @@ pub(crate) const DATASET_CREDENTIAL_TEMPLATE: &str = r###"
     "issuanceDate": "2000-01-01T00:00:00.0Z"
 }
 "###;
-pub(crate) const DATASET_ATTRIBUTE: &str = "dataset";
+pub(crate) const DATA_ATTRIBUTE: &str = "dataset";

--- a/trustchain-api/src/lib.rs
+++ b/trustchain-api/src/lib.rs
@@ -1,6 +1,6 @@
 //! API for DID, VC and VP functionality.
 pub mod api;
-use crate::api::{TrustchainDIDAPI, TrustchainVCAPI, TrustchainVPAPI};
+use crate::api::{TrustchainDIDAPI, TrustchainDataAPI, TrustchainVCAPI, TrustchainVPAPI};
 
 /// A type for implementing CLI traits on.
 pub struct TrustchainAPI;
@@ -8,3 +8,23 @@ pub struct TrustchainAPI;
 impl TrustchainDIDAPI for TrustchainAPI {}
 impl TrustchainVCAPI for TrustchainAPI {}
 impl TrustchainVPAPI for TrustchainAPI {}
+impl TrustchainDataAPI for TrustchainAPI {}
+
+pub(crate) const DATASET_CREDENTIAL_TEMPLATE: &str = r#"
+{
+    "@context": [
+      "https://www.w3.org/2018/credentials/v1",
+      "https://www.w3.org/2018/credentials/examples/v1",
+      "https://schema.org/"
+    ],
+    "type": [
+      "VerifiableCredential"
+    ],
+    "credentialSubject": {
+      "dataset": ""
+    },
+    "issuer": "did:ion:test:EiDSE2lEM65nYrEqVvQO5C3scYhkv1KmZzq0S0iZmNKf1Q"
+}
+"#;
+pub(crate) const DATASET_ATTRIBUTE: &str = "dataset";
+pub(crate) const VC_XATTR_NAME: &str = "vc";

--- a/trustchain-api/src/lib.rs
+++ b/trustchain-api/src/lib.rs
@@ -10,7 +10,7 @@ impl TrustchainVCAPI for TrustchainAPI {}
 impl TrustchainVPAPI for TrustchainAPI {}
 impl TrustchainDataAPI for TrustchainAPI {}
 
-pub(crate) const DATASET_CREDENTIAL_TEMPLATE: &str = r#"
+pub(crate) const DATASET_CREDENTIAL_TEMPLATE: &str = r###"
 {
     "@context": [
       "https://www.w3.org/2018/credentials/v1",
@@ -23,8 +23,8 @@ pub(crate) const DATASET_CREDENTIAL_TEMPLATE: &str = r#"
     "credentialSubject": {
       "dataset": ""
     },
-    "issuer": "did:ion:test:EiDSE2lEM65nYrEqVvQO5C3scYhkv1KmZzq0S0iZmNKf1Q"
+    "issuer": "did:ion:test:XYZ",
+    "issuanceDate": "2000-01-01T00:00:00.0Z"
 }
-"#;
+"###;
 pub(crate) const DATASET_ATTRIBUTE: &str = "dataset";
-pub(crate) const VC_XATTR_NAME: &str = "vc";

--- a/trustchain-api/src/lib.rs
+++ b/trustchain-api/src/lib.rs
@@ -12,8 +12,8 @@ impl TrustchainDataAPI for TrustchainAPI {}
 
 /// A template for data credentials.
 /// Uses the dataset attribute from schema.org.
-/// The context (i.e. "https://schema.org/") is checked by the SSI library against the list at:
-/// https://github.com/spruceid/ssi/blob/976e2607080c20cd5789b977e477e98b6417f8af/ssi-json-ld/src/lib.rs#L41
+/// The context (i.e. ["https://schema.org/"](https://schema.org/)) is checked by the SSI library
+/// against this [list](https://github.com/spruceid/ssi/blob/976e2607080c20cd5789b977e477e98b6417f8af/ssi-json-ld/src/lib.rs#L41)
 /// with an exact string match. (Therefore the trailing "/" is required.)
 pub(crate) const DATA_CREDENTIAL_TEMPLATE: &str = r###"
 {

--- a/trustchain-cli/src/bin/main.rs
+++ b/trustchain-cli/src/bin/main.rs
@@ -267,7 +267,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                             handle_credential_error(&cred_err);
                         }
                         Ok(_) => {
-                            println!("Proof... ✅");
+                            println!("Proof.... ✅");
                             println!("Issuer... ✅");
                         }
                     }
@@ -364,7 +364,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                             println!("Digest... ❌ (mismatched dataset hash digests)");
                         }
                         Ok(_) => {
-                            println!("Proof... ✅");
+                            println!("Proof.... ✅");
                             println!("Issuer... ✅");
                             println!("Digest... ✅");
                         }
@@ -420,15 +420,15 @@ fn handle_credential_error(err: &CredentialError) {
             println!("Proof... ❌ (missing verification method)");
         }
         _err @ CredentialError::NoIssuerPresent => {
-            println!("Proof... ✅");
+            println!("Proof.... ✅");
             println!("Issuer... ❌ (missing issuer)");
         }
         _err @ CredentialError::VerifierError(_) => {
-            println!("Proof... ✅");
+            println!("Proof.... ✅");
             println!("Issuer... ❌ (with verifier error)");
         }
         _err @ CredentialError::FailedToDecodeJWT => {
-            println!("Proof... ❌");
+            println!("Proof.... ❌");
             println!("Issuer... ❌");
         }
     }

--- a/trustchain-cli/src/bin/main.rs
+++ b/trustchain-cli/src/bin/main.rs
@@ -362,6 +362,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                         Err(DataCredentialError::MismatchedHashDigests(_, _)) => {
                             println!("Digest... ❌ (mismatched data hash digests)");
                         }
+                        Err(DataCredentialError::MissingAttribute(att)) => {
+                            println!("Invalid credential... ❌ (missing attribute: \"{att}\")");
+                        }
+                        Err(DataCredentialError::ManyCredentialSubject(subjects)) => {
+                            println!("Invalid credential... ❌ (only one subject permitted, multiple subjects found: {subjects:?})");
+                        }
                         Ok(_) => {
                             println!("Proof.... ✅");
                             println!("Issuer... ✅");

--- a/trustchain-cli/src/bin/main.rs
+++ b/trustchain-cli/src/bin/main.rs
@@ -15,12 +15,14 @@ use trustchain_cli::config::cli_config;
 use trustchain_core::{
     vc::{CredentialError, DataCredentialError},
     verifier::Verifier,
+    JSON_FILE_EXTENSION,
 };
 use trustchain_ion::{
     attest::attest_operation,
     create::{create_operation, create_operation_mnemonic},
     trustchain_resolver,
     verifier::TrustchainVerifier,
+    CREATE_OPERATION_FILENAME_PREFIX,
 };
 
 fn cli() -> Command {
@@ -131,6 +133,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     if mnemonic && file_path.is_some() {
                         panic!("Please use only one of '--file_path' and '--mnemonic'.")
                     }
+                    let filename: String;
                     if !mnemonic {
                         // Read doc state from file path
                         let doc_state = if let Some(file_path) = file_path {
@@ -138,13 +141,21 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                         } else {
                             None
                         };
-                        create_operation(doc_state, verbose)?;
+                        filename = create_operation(doc_state, verbose)?;
                     } else {
                         let mut mnemonic = String::new();
                         println!("Enter a mnemonic:");
                         std::io::stdin().read_line(&mut mnemonic).unwrap();
-                        create_operation_mnemonic(&mnemonic, None)?;
+                        filename = create_operation_mnemonic(&mnemonic, None)?;
                     }
+                    println!(
+                        "Created new DID: {}",
+                        filename
+                            .strip_prefix(CREATE_OPERATION_FILENAME_PREFIX)
+                            .unwrap_or_else(|| &filename)
+                            .strip_suffix(JSON_FILE_EXTENSION)
+                            .unwrap_or_else(|| &filename)
+                    );
                 }
                 Some(("attest", sub_matches)) => {
                     let did = sub_matches.get_one::<String>("did").unwrap();

--- a/trustchain-cli/src/bin/main.rs
+++ b/trustchain-cli/src/bin/main.rs
@@ -322,7 +322,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     let key_id = sub_matches
                         .get_one::<String>("key_id")
                         .map(|string| string.as_str());
-                    let dataset = Path::new(sub_matches.get_one::<String>("dataset_file").unwrap());
+                    let dataset = Path::new(sub_matches.get_one::<String>("data_file").unwrap());
                     let dataset_with_proof = TrustchainAPI::sign_dataset(
                         &dataset,
                         did,
@@ -341,7 +341,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                         Some(time) => time.parse::<u64>().unwrap(),
                         None => cli_config().root_event_time.into(),
                     };
-                    let dataset = Path::new(sub_matches.get_one::<String>("dataset_file").unwrap());
+                    let dataset = Path::new(sub_matches.get_one::<String>("data_file").unwrap());
 
                     let verify_result = TrustchainAPI::verify_dataset(
                         &dataset,

--- a/trustchain-cli/src/bin/main.rs
+++ b/trustchain-cli/src/bin/main.rs
@@ -83,6 +83,28 @@ fn cli() -> Command {
                         .arg(arg!(-t --root_event_time <ROOT_EVENT_TIME>).required(false)),
                 ),
         )
+        .subcommand(
+            Command::new("data")
+                .about("Credentials for data functionality: sign and verify.")
+                .subcommand_required(true)
+                .arg_required_else_help(true)
+                .allow_external_subcommands(true)
+                .subcommand(
+                    Command::new("sign")
+                        .about("Signs a dataset.")
+                        .arg(arg!(-v - -verbose).action(ArgAction::SetTrue))
+                        .arg(arg!(-d --did <DID>).required(true))
+                        .arg(arg!(-f --data_file <DATA_FILE>).required(false))
+                        .arg(arg!(--key_id <KEY_ID>).required(false)),
+                )
+                .subcommand(
+                    Command::new("verify")
+                        .about("Verifies a dataset.")
+                        .arg(arg!(-v - -verbose).action(ArgAction::Count))
+                        .arg(arg!(-f --data_file <DATA_FILE>).required(false))
+                        .arg(arg!(-t --root_event_time <ROOT_EVENT_TIME>).required(false)),
+                ),
+        )
 }
 
 #[tokio::main]

--- a/trustchain-cli/src/bin/main.rs
+++ b/trustchain-cli/src/bin/main.rs
@@ -13,7 +13,6 @@ use trustchain_api::{
 };
 use trustchain_cli::config::cli_config;
 use trustchain_core::{
-    chain::DIDChain,
     vc::{CredentialError, DataCredentialError},
     verifier::Verifier,
 };

--- a/trustchain-cli/src/bin/main.rs
+++ b/trustchain-cli/src/bin/main.rs
@@ -33,7 +33,7 @@ fn cli() -> Command {
         .allow_external_subcommands(true)
         .subcommand(
             Command::new("did")
-                .about("DID functionality: create, attest, resolve.")
+                .about("DID functionality: create, attest, resolve, verify.")
                 .subcommand_required(true)
                 .arg_required_else_help(true)
                 .allow_external_subcommands(true)
@@ -91,7 +91,7 @@ fn cli() -> Command {
         )
         .subcommand(
             Command::new("data")
-                .about("Credentials for data functionality: sign and verify.")
+                .about("Data provenance functionality: sign and verify.")
                 .subcommand_required(true)
                 .arg_required_else_help(true)
                 .allow_external_subcommands(true)

--- a/trustchain-cli/src/bin/main.rs
+++ b/trustchain-cli/src/bin/main.rs
@@ -13,6 +13,7 @@ use trustchain_api::{
 };
 use trustchain_cli::config::cli_config;
 use trustchain_core::{
+    chain::DIDChain,
     vc::{CredentialError, DataCredentialError},
     verifier::Verifier,
 };
@@ -252,26 +253,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     .await;
                     // Handle result
                     match verify_result {
-                        _err @ Err(CredentialError::VerificationResultError(_)) => {
-                            println!("Proof... ❌ Invalid");
-                        }
-                        _err @ Err(CredentialError::NoProofPresent) => {
-                            println!("Proof... ❌ (missing proof)");
-                        }
-                        _err @ Err(CredentialError::MissingVerificationMethod) => {
-                            println!("Proof... ❌ (missing verification method)");
-                        }
-                        _err @ Err(CredentialError::NoIssuerPresent) => {
-                            println!("Proof... ✅");
-                            println!("Issuer... ❌ (missing issuer)");
-                        }
-                        _err @ Err(CredentialError::VerifierError(_)) => {
-                            println!("Proof... ✅");
-                            println!("Issuer... ❌ (with verifier error)");
-                        }
-                        _err @ Err(CredentialError::FailedToDecodeJWT) => {
-                            println!("Proof... ❌");
-                            println!("Issuer... ❌");
+                        Err(cred_err) => {
+                            handle_credential_error(&cred_err);
                         }
                         Ok(_) => {
                             println!("Proof... ✅");
@@ -363,32 +346,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     )
                     .await;
                     // Handle result
-                    // TODO: avoid repetition (see similar error handling above).
                     match verify_result {
                         ref _e @ Err(DataCredentialError::CredentialError(ref cred_err)) => {
-                            match cred_err {
-                                _err @ CredentialError::VerificationResultError(_) => {
-                                    println!("Proof... ❌ Invalid");
-                                }
-                                _err @ CredentialError::NoProofPresent => {
-                                    println!("Proof... ❌ (missing proof)");
-                                }
-                                _err @ CredentialError::MissingVerificationMethod => {
-                                    println!("Proof... ❌ (missing verification method)");
-                                }
-                                _err @ CredentialError::NoIssuerPresent => {
-                                    println!("Proof... ✅");
-                                    println!("Issuer... ❌ (missing issuer)");
-                                }
-                                _err @ CredentialError::VerifierError(_) => {
-                                    println!("Proof... ✅");
-                                    println!("Issuer... ❌ (with verifier error)");
-                                }
-                                _err @ CredentialError::FailedToDecodeJWT => {
-                                    println!("Proof... ❌");
-                                    println!("Issuer... ❌");
-                                }
-                            }
+                            handle_credential_error(cred_err);
                         }
                         _e @ Err(DataCredentialError::MismatchedHashDigests(_, _)) => {
                             println!("Digest... ❌ (mismatched dataset hash digests)");
@@ -436,4 +396,30 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         _ => panic!("Unrecognised subcommand."),
     }
     Ok(())
+}
+
+fn handle_credential_error(err: &CredentialError) {
+    match err {
+        _err @ CredentialError::VerificationResultError(_) => {
+            println!("Proof... ❌ Invalid");
+        }
+        _err @ CredentialError::NoProofPresent => {
+            println!("Proof... ❌ (missing proof)");
+        }
+        _err @ CredentialError::MissingVerificationMethod => {
+            println!("Proof... ❌ (missing verification method)");
+        }
+        _err @ CredentialError::NoIssuerPresent => {
+            println!("Proof... ✅");
+            println!("Issuer... ❌ (missing issuer)");
+        }
+        _err @ CredentialError::VerifierError(_) => {
+            println!("Proof... ✅");
+            println!("Issuer... ❌ (with verifier error)");
+        }
+        _err @ CredentialError::FailedToDecodeJWT => {
+            println!("Proof... ❌");
+            println!("Issuer... ❌");
+        }
+    }
 }

--- a/trustchain-cli/src/bin/main.rs
+++ b/trustchain-cli/src/bin/main.rs
@@ -78,16 +78,14 @@ fn cli() -> Command {
                         .about("Signs a credential.")
                         .arg(arg!(-v - -verbose).action(ArgAction::SetTrue))
                         .arg(arg!(-d --did <DID>).required(true))
-                        // TODO: credential file Should be required?
-                        .arg(arg!(-f --credential_file <CREDENTIAL_FILE>).required(false))
+                        .arg(arg!(-f --credential_file <CREDENTIAL_FILE>).required(true))
                         .arg(arg!(--key_id <KEY_ID>).required(false)),
                 )
                 .subcommand(
                     Command::new("verify")
                         .about("Verifies a credential.")
                         .arg(arg!(-v - -verbose).action(ArgAction::Count))
-                        // TODO: credential file Should be required?
-                        .arg(arg!(-f --credential_file <CREDENTIAL_FILE>).required(false))
+                        .arg(arg!(-f --credential_file <CREDENTIAL_FILE>).required(true))
                         .arg(arg!(-t --root_event_time <ROOT_EVENT_TIME>).required(false)),
                 ),
         )
@@ -314,7 +312,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                         .get_one::<String>("key_id")
                         .map(|string| string.as_str());
                     let data = Path::new(sub_matches.get_one::<String>("data_file").unwrap());
-                    let bytes = std::fs::read(data).unwrap(); // TODO: handle with ? or expect.
+                    let bytes = std::fs::read(data)?;
 
                     let data_with_proof = TrustchainAPI::sign_data(
                         &bytes,
@@ -343,7 +341,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                             let buffer = BufReader::new(stdin());
                             serde_json::from_reader(buffer).unwrap()
                         };
-                    let bytes = std::fs::read(data).unwrap(); // TODO: handle with ? or expect.
+                    let bytes = std::fs::read(data)?;
 
                     let verify_result = TrustchainAPI::verify_data(
                         &bytes,

--- a/trustchain-core/src/key_manager.rs
+++ b/trustchain-core/src/key_manager.rs
@@ -3,7 +3,6 @@ use crate::{JSON_FILE_EXTENSION, TRUSTCHAIN_DATA};
 use serde_json::{from_str, to_string_pretty as to_json};
 use ssi::jwk::JWK;
 use ssi::one_or_many::OneOrMany;
-use std::fmt::format;
 use std::fs::{File, OpenOptions};
 use std::io::{Read, Write};
 use std::path::{Path, PathBuf};

--- a/trustchain-core/src/key_manager.rs
+++ b/trustchain-core/src/key_manager.rs
@@ -1,8 +1,9 @@
 //! Key management API with default implementations.
-use crate::TRUSTCHAIN_DATA;
+use crate::{JSON_FILE_EXTENSION, TRUSTCHAIN_DATA};
 use serde_json::{from_str, to_string_pretty as to_json};
 use ssi::jwk::JWK;
 use ssi::one_or_many::OneOrMany;
+use std::fmt::format;
 use std::fs::{File, OpenOptions};
 use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
@@ -151,10 +152,10 @@ pub trait KeyManager {
     ) -> Result<PathBuf, KeyManagerError> {
         // Get the stem for the corresponding key type
         let file_name = match key_type {
-            KeyType::UpdateKey => "update_key.json",
-            KeyType::NextUpdateKey => "next_update_key.json",
-            KeyType::RecoveryKey => "recovery_key.json",
-            KeyType::SigningKey => "signing_key.json",
+            KeyType::UpdateKey => format!("update_key{}", JSON_FILE_EXTENSION),
+            KeyType::NextUpdateKey => format!("next_update_key{}", JSON_FILE_EXTENSION),
+            KeyType::RecoveryKey => format!("recovery_key{}", JSON_FILE_EXTENSION),
+            KeyType::SigningKey => format!("signing_key{}", JSON_FILE_EXTENSION),
         };
 
         // Get environment for TRUSTCHAIN_DATA

--- a/trustchain-core/src/lib.rs
+++ b/trustchain-core/src/lib.rs
@@ -30,3 +30,5 @@ pub const TRUSTCHAIN_PROOF_SERVICE_ID_VALUE: &str = "trustchain-controller-proof
 
 /// The value of the type for the service containing a Trustchain controller proof within a DID document.
 pub const TRUSTCHAIN_PROOF_SERVICE_TYPE_VALUE: &str = "TrustchainProofService";
+
+pub const JSON_FILE_EXTENSION: &str = ".json";

--- a/trustchain-core/src/lib.rs
+++ b/trustchain-core/src/lib.rs
@@ -31,4 +31,5 @@ pub const TRUSTCHAIN_PROOF_SERVICE_ID_VALUE: &str = "trustchain-controller-proof
 /// The value of the type for the service containing a Trustchain controller proof within a DID document.
 pub const TRUSTCHAIN_PROOF_SERVICE_TYPE_VALUE: &str = "TrustchainProofService";
 
+/// String slice for JSON file extension for consistency.
 pub const JSON_FILE_EXTENSION: &str = ".json";

--- a/trustchain-core/src/utils.rs
+++ b/trustchain-core/src/utils.rs
@@ -301,18 +301,6 @@ pub fn generate_key() -> JWK {
     JWK::generate_secp256k1().expect("Could not generate key.")
 }
 
-#[allow(dead_code)]
-pub fn set_panic_hook() {
-    // When the `console_error_panic_hook` feature is enabled, we can call the
-    // `set_panic_hook` function at least once during initialization, and then
-    // we will get better error messages if our code ever panics.
-    //
-    // For more details see
-    // <https://github.com/rustwasm/console_error_panic_hook#readme>
-    #[cfg(feature = "console_error_panic_hook")]
-    console_error_panic_hook::set_once();
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/trustchain-core/src/vc.rs
+++ b/trustchain-core/src/vc.rs
@@ -26,6 +26,23 @@ pub enum CredentialError {
     VerificationResultError(VerificationResult),
 }
 
+/// An error relating to a verifiable credential for a dataset.
+#[derive(Error, Debug)]
+pub enum DataCredentialError {
+    /// Wrapped CredentialError
+    #[error("Credential error: {0:?}")]
+    CredentialError(CredentialError),
+    /// Hash digests do not match.
+    #[error("Hash digests do not match. Expected: {0}. Actual: {1}.")]
+    MismatchedHashDigests(String, String),
+}
+
+impl From<CredentialError> for DataCredentialError {
+    fn from(err: CredentialError) -> Self {
+        DataCredentialError::CredentialError(err)
+    }
+}
+
 impl From<VerifierError> for CredentialError {
     fn from(err: VerifierError) -> Self {
         CredentialError::VerifierError(err)

--- a/trustchain-core/src/vc.rs
+++ b/trustchain-core/src/vc.rs
@@ -1,6 +1,6 @@
 //! Verifiable credential functionality for Trustchain.
 use crate::verifier::VerifierError;
-use ssi::vc::VerificationResult;
+use ssi::vc::{CredentialSubject, OneOrMany, VerificationResult};
 use thiserror::Error;
 
 /// An error relating to verifiable credentials and presentations.
@@ -35,6 +35,12 @@ pub enum DataCredentialError {
     /// Hash digests do not match.
     #[error("Hash digests do not match. Expected: {0}. Actual: {1}.")]
     MismatchedHashDigests(String, String),
+    /// Multiple credential subjects
+    #[error("Multiple credential subjects: {0:?}")]
+    ManyCredentialSubject(OneOrMany<CredentialSubject>),
+    /// Missing attribute
+    #[error("Missing attribute: {0}")]
+    MissingAttribute(String),
 }
 
 impl From<CredentialError> for DataCredentialError {

--- a/trustchain-ion/src/attest.rs
+++ b/trustchain-ion/src/attest.rs
@@ -1,5 +1,6 @@
 //! ION operation for DID attestation.
 use crate::ion::IONTest as ION;
+use crate::ATTEST_OPERATION_FILENAME_PREFIX;
 use did_ion::sidetree::DIDStatePatch;
 use did_ion::sidetree::PublicKeyJwk;
 use did_ion::sidetree::{DIDSuffix, Operation, Sidetree};
@@ -10,6 +11,7 @@ use trustchain_core::key_manager::{ControllerKeyManager, KeyType};
 use trustchain_core::resolver::TrustchainResolver;
 use trustchain_core::subject::Subject;
 use trustchain_core::utils::get_operations_path;
+use trustchain_core::JSON_FILE_EXTENSION;
 use trustchain_core::TRUSTCHAIN_PROOF_SERVICE_ID_VALUE;
 
 use crate::controller::IONController;
@@ -103,8 +105,10 @@ pub async fn attest_operation(
     // operation_manager.save(operation, OperationType::Update)?;
     let path = get_operations_path()?;
     let path = path.join(format!(
-        "attest_operation_{}.json",
-        controller.controlled_did_suffix()
+        "{}{}{}",
+        ATTEST_OPERATION_FILENAME_PREFIX,
+        controller.controlled_did_suffix(),
+        JSON_FILE_EXTENSION
     ));
     std::fs::write(path, to_json(&operation).unwrap())?;
 

--- a/trustchain-ion/src/commitment.rs
+++ b/trustchain-ion/src/commitment.rs
@@ -463,14 +463,8 @@ impl IONCommitment {
         block_header: Vec<u8>,
     ) -> CommitmentResult<Self> {
         // Extract the public keys and endpoints as the expected data.
-        let keys = match did_doc.get_keys() {
-            Some(x) => x,
-            None => vec![],
-        };
-        let endpoints = match did_doc.get_endpoints() {
-            Some(x) => x,
-            None => vec![],
-        };
+        let keys = did_doc.get_keys().unwrap_or_default();
+        let endpoints = did_doc.get_endpoints().unwrap_or_default();
         let expected_data = json!([keys, endpoints]);
 
         // Construct the core index file commitment first, to get the index of the chunk file delta for this DID.
@@ -931,7 +925,7 @@ mod tests {
 
         // The first one commits to the chunk file CID and is expected
         // to contain the same data as the iterated commitment.
-        let chunk_file_commitment = commitments.get(0).unwrap();
+        let chunk_file_commitment = commitments.first().unwrap();
         assert_eq!(chunk_file_commitment.hash().unwrap(), chunk_file_cid);
         assert_eq!(expected_data, chunk_file_commitment.expected_data());
 

--- a/trustchain-ion/src/create.rs
+++ b/trustchain-ion/src/create.rs
@@ -3,6 +3,7 @@ use crate::attestor::{AttestorData, IONAttestor};
 use crate::controller::{ControllerData, IONController};
 use crate::ion::IONTest as ION;
 use crate::mnemonic::IONKeys;
+use crate::CREATE_OPERATION_FILENAME_PREFIX;
 use bip39::Mnemonic;
 use did_ion::sidetree::{CreateOperation, DIDStatePatch};
 use did_ion::sidetree::{DocumentState, PublicKeyEntry, PublicKeyJwk};
@@ -13,6 +14,7 @@ use ssi::one_or_many::OneOrMany;
 use std::convert::TryFrom;
 use trustchain_core::controller::Controller;
 use trustchain_core::utils::{generate_key, get_operations_path};
+use trustchain_core::JSON_FILE_EXTENSION;
 
 /// Collection of methods to return DID information from an operation.
 pub trait OperationDID {
@@ -73,8 +75,10 @@ fn write_create_operation(
     // Write create operation to push to ION server
     let path = get_operations_path().unwrap();
     let filename = format!(
-        "create_operation_{}.json",
-        controller.controlled_did_suffix()
+        "{}{}{}",
+        CREATE_OPERATION_FILENAME_PREFIX,
+        controller.controlled_did_suffix(),
+        JSON_FILE_EXTENSION
     );
     std::fs::write(
         path.join(&filename),
@@ -275,7 +279,10 @@ mod test {
 
         // Try to read outputted create operations and check they deserialize
         let path = get_operations_path()?;
-        let pattern = path.join("create_operation_*.json");
+        let pattern = path.join(format!(
+            "{}*{}",
+            CREATE_OPERATION_FILENAME_PREFIX, JSON_FILE_EXTENSION
+        ));
         let pattern = pattern.into_os_string().into_string().unwrap();
         let paths = glob(pattern.as_str())?;
 

--- a/trustchain-ion/src/lib.rs
+++ b/trustchain-ion/src/lib.rs
@@ -168,6 +168,7 @@ pub enum TrustchainBitcoinError {
 pub const CONTROLLER_KEY: &str = "controller";
 pub const CREATE_OPERATION_FILENAME_PREFIX: &str = "create_operation_";
 pub const ATTEST_OPERATION_FILENAME_PREFIX: &str = "attest_operation_";
+// TODO: uncomment when update operation functionality merged
 // pub const UPDATE_OPERATION_FILENAME_PREFIX: &str = "update_operation_";
 
 // ION

--- a/trustchain-ion/src/lib.rs
+++ b/trustchain-ion/src/lib.rs
@@ -166,6 +166,9 @@ pub enum TrustchainBitcoinError {
 
 // DID
 pub const CONTROLLER_KEY: &str = "controller";
+pub const CREATE_OPERATION_FILENAME_PREFIX: &str = "create_operation_";
+pub const ATTEST_OPERATION_FILENAME_PREFIX: &str = "attest_operation_";
+// pub const UPDATE_OPERATION_FILENAME_PREFIX: &str = "update_operation_";
 
 // ION
 pub const ION_METHOD: &str = "ion";


### PR DESCRIPTION
Closes #181.

Adds a new `data` subcommand to the CLI. This is similar to the `vc` subcommand, but instead for signing and verifying a credential for a data file.

Note that the SHA-256 hashing algorithm is used (implicitly) to compute the hash identifier for the dataset, e.g.:
```json
  "credentialSubject": {
    "dataset": "03d3711e0ec7585fdf635535665c3d9e376d36c0f89024d30fa7587cd247f6b1"
  },
```
Ideally we should make this choice of hash function explicit, but it's unclear (to me) where this information belongs inside the credential.

(There are also some calls to `unwrap()` that need to be fixed before merging.)