### PR TITLE
Fix trustchain path dependency versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,8 +86,8 @@ trustchain-http = { workspace = true, optional = true }
 trustchain-ion = { workspace = true, optional = true }
 
 [features]
-default = ["api"]
+default = ["api", "ion"]
 http = ["api", "dep:trustchain-http"]
 api = ["ion", "dep:trustchain-api"]
 ion = ["dep:trustchain-ion"]
-ffi = ["api", "dep:trustchain-ffi"]
+ffi = ["http", "dep:trustchain-ffi"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,16 +72,22 @@ toml = "0.7.2"
 tower = "0.4"
 tracing = "0.1"
 tracing-subscriber = "0.3"
-
-[dependencies]
 trustchain-api = { path = "crates/trustchain-api", version = "0.1.0" }
 trustchain-core = { path = "crates/trustchain-core", version = "0.2.0" }
-trustchain-ffi = { path = "crates/trustchain-ffi", version = "0.1.0", optional = true }
-trustchain-http = { path = "crates/trustchain-http", version = "0.1.0", optional = true }
-trustchain-ion = { path = "crates/trustchain-ion", version = "0.2.0", optional = true }
+trustchain-ffi = { path = "crates/trustchain-ffi", version = "0.1.0" }
+trustchain-http = { path = "crates/trustchain-http", version = "0.1.0" }
+trustchain-ion = { path = "crates/trustchain-ion", version = "0.2.0" }
+
+[dependencies]
+trustchain-api = { workspace = true, optional = true }
+trustchain-core = { workspace = true }
+trustchain-ffi = { workspace = true, optional = true }
+trustchain-http = { workspace = true, optional = true }
+trustchain-ion = { workspace = true, optional = true }
 
 [features]
-default = []
-http = ["dep:trustchain-http"]
+default = ["api"]
+http = ["api", "dep:trustchain-http"]
+api = ["ion", "dep:trustchain-api"]
 ion = ["dep:trustchain-ion"]
-ffi = ["dep:trustchain-ffi"]
+ffi = ["api", "dep:trustchain-ffi"]

--- a/crates/trustchain-api/Cargo.toml
+++ b/crates/trustchain-api/Cargo.toml
@@ -18,8 +18,8 @@ hex = { workspace = true }
 serde_json = { workspace = true }
 sha2 = { workspace = true }
 ssi = { workspace = true, features = ["http-did", "secp256k1"] }
-trustchain-core = { path = "../trustchain-core" }
-trustchain-ion = { path = "../trustchain-ion" }
+trustchain-core = { path = "../trustchain-core", version = "0.2.0" }
+trustchain-ion = { path = "../trustchain-ion", version = "0.2.0" }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["full"] }

--- a/crates/trustchain-api/Cargo.toml
+++ b/crates/trustchain-api/Cargo.toml
@@ -18,8 +18,8 @@ hex = { workspace = true }
 serde_json = { workspace = true }
 sha2 = { workspace = true }
 ssi = { workspace = true, features = ["http-did", "secp256k1"] }
-trustchain-core = { path = "../trustchain-core", version = "0.2.0" }
-trustchain-ion = { path = "../trustchain-ion", version = "0.2.0" }
+trustchain-core = { workspace = true }
+trustchain-ion = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["full"] }

--- a/crates/trustchain-ffi/Cargo.toml
+++ b/crates/trustchain-ffi/Cargo.toml
@@ -26,7 +26,7 @@ ssi = { workspace = true, features = ["http-did", "secp256k1"] }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread"] }
 toml = { workspace = true }
-trustchain-api = { path = "../trustchain-api" }
-trustchain-core = { path = "../trustchain-core" }
-trustchain-http = { path = "../trustchain-http" }
-trustchain-ion = { path = "../trustchain-ion" }
+trustchain-api = { workspace = true }
+trustchain-core = { workspace = true }
+trustchain-http = { workspace = true }
+trustchain-ion = { workspace = true }

--- a/crates/trustchain-http/Cargo.toml
+++ b/crates/trustchain-http/Cargo.toml
@@ -40,9 +40,9 @@ toml = { workspace = true }
 tower = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
-trustchain-api = { path = "../trustchain-api" }
-trustchain-core = { path = "../trustchain-core" }
-trustchain-ion = { path = "../trustchain-ion" }
+trustchain-api = { workspace = true }
+trustchain-core = { workspace = true }
+trustchain-ion = { workspace = true }
 
 [dev-dependencies]
 axum-test-helper = { workspace = true }

--- a/crates/trustchain-ion/Cargo.toml
+++ b/crates/trustchain-ion/Cargo.toml
@@ -34,7 +34,7 @@ ssi = { workspace = true, features = ["http-did", "secp256k1"] }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 toml = { workspace = true }
-trustchain-core = { path = "../trustchain-core", version = "0.2.0" }
+trustchain-core = { workspace = true }
 
 [dev-dependencies]
 glob = { workspace = true }

--- a/crates/trustchain-ion/Cargo.toml
+++ b/crates/trustchain-ion/Cargo.toml
@@ -34,7 +34,7 @@ ssi = { workspace = true, features = ["http-did", "secp256k1"] }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 toml = { workspace = true }
-trustchain-core = { path = "../trustchain-core" }
+trustchain-core = { path = "../trustchain-core", version = "0.2.0" }
 
 [dev-dependencies]
 glob = { workspace = true }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 //! Trustchain reference implementation.
 
+#[cfg(feature = "api")]
 pub use trustchain_api as api;
 pub use trustchain_core as core;
 #[cfg(feature = "ffi")]


### PR DESCRIPTION
This PR:
- Adds versions (required for publishing) to trustchain crate path deps
- Adds trustchain deps as workspace deps
- Revises features in trustchain crate