### PR TITLE
Update CLI trustchain deps to workspace deps

### DIFF
--- a/crates/trustchain-cli/Cargo.toml
+++ b/crates/trustchain-cli/Cargo.toml
@@ -21,7 +21,7 @@ serde_json = { workspace = true }
 ssi = { workspace = true, features = ["http-did", "secp256k1"] }
 tokio = { workspace = true, features = ["full"] }
 toml = { workspace = true }
-trustchain-api = { path = "../trustchain-api" }
-trustchain-core = { path = "../trustchain-core" }
-trustchain-http = { path = "../trustchain-http" }
-trustchain-ion = { path = "../trustchain-ion" }
+trustchain-api = { workspace = true }
+trustchain-core = { workspace = true }
+trustchain-http = { workspace = true }
+trustchain-ion = { workspace = true }


### PR DESCRIPTION
This PR updates the CLI trustchain deps to be workspace deps.