### PR TITLE
Fix sed command for mac OS

### DIFF
--- a/docs/ion.md
+++ b/docs/ion.md
@@ -309,7 +309,7 @@ Run the following command to create an alias, making to easy to access the CLI:
         ```
     === "macOS"
         ```console
-        $ sed -i '' $'1s|^|rpcuser=admin\\\nrpcpassword=$RPC_PASSWORD\\\n|' $BITCOIN_DATA/bitcoin.conf
+        $ sed -i '' $'1s|^|rpcuser=admin\\\nrpcpassword='"$RPC_PASSWORD"$'\\\n|' $BITCOIN_DATA/bitcoin.conf
         ```
 
     To confirm these changes were made correctly, check the first two lines in the `bitcoin.conf` file by running:


### PR DESCRIPTION
Newline character `\n` is not interpreted correctly on mac OS. Solution found by combining [this](https://stackoverflow.com/questions/16576197/how-to-add-new-line-using-sed-on-macos) and [this](https://stackoverflow.com/questions/49691071/how-to-use-variable-in-sed-command-in-shell).